### PR TITLE
new:dev: corrected link to git video lectures page

### DIFF
--- a/docs/source/i524/lectures-collab.csv
+++ b/docs/source/i524/lectures-collab.csv
@@ -1,4 +1,4 @@
-Github, Overview and Introduction, `Web page <lesson/prg/github.html#video-lectures-on-github>`_, 
+Github, Overview and Introduction, `Web page <../lesson/prg/github.html#video-lectures-on-github>`_, 
       , Install Instructions, `Web page <https://www.atlassian.com/git/tutorials/install-git>`_,    
       , config, `Video <https://www.youtube.com/watch?v=ZChtKFLiaNw>`_, 2:47
       , fork, `Video <https://www.youtube.com/watch?v=5oJHRbqEofs>`_, 1:41


### PR DESCRIPTION
Fixed link to main page with git video lectures.