### PR TITLE
new:dev: add explenation for Appfog, Dream:Lab, MySQL, ZHT, and Rya

### DIFF
--- a/docs/source/i524/technologies.rst
+++ b/docs/source/i524/technologies.rst
@@ -196,6 +196,21 @@ Application and Analytics
 
 63. Parasol
 64. Dream:Lab
+
+    DREAM:Lab stands for “Distributed Research on Emerging
+    Applications and Machines Lab.” :cite:`dream` DREAM:Lab is centered
+    around distributed systems research to enable expeditious
+    utilization of distributed data and computing systems. :cite:`dream`
+    DREAM:Lab utilizes the “capabilities of hundereds of personal
+    computers” to allow access to supercomputing resources to average
+    individuals. :cite:`rao` The DREAM:Lab pursues this goal by utilizing
+    distributed computing. :cite:`rao` Distributed computing consists of
+    independent computing resources that communicate with each other
+    over a network. :cite:`denero` A large, complex computing problem is
+    broken down into smaller, more manageable tasks and then these
+    tasks are distributed to the various components of the distributed
+    computing system. :cite:`denero`
+    
 65. Google Fusion Tables
     
     Fusion Tables is a cloud based services, provided by Google for
@@ -346,6 +361,19 @@ Application Hosting Frameworks
 91. Jelastic
 92. Stackato
 93. appfog
+
+    According to :cite:`wee`, “AppFog is a platform as a service (PaaS)
+    provider.” Platform as a service provides a platform for the
+    development of web applications without the necessity of
+    purchasing the software and infrastructure that supports
+    it. :cite:`kepes` PaaS provides an environment for the creation of
+    software. :cite:`kepes` The underlying support infrastructure that AppFog
+    provides includes things such as runtime, middleware, o/s,
+    virtualization, servers, storage, and networking. :cite:`appfog` AppFog
+    is based on VMWare’s CloudFoundry project. :cite:`wee` It gets things
+    such as MySQL, Mongo, Reddis, memCache, etc. running and then
+    manages them. :cite:`tweney`
+    
 94. CloudBees
 95. Engine Yard
 96. (CloudControl)
@@ -905,6 +933,18 @@ SQL(NewSQL)
 
 201. SQLite
 202. MySQL
+
+     MySQL is a relational database management system. :cite:`devmysql` SQL
+     is an acronym for Structured Query Language and is a standardized
+     language used to interact with the databases. :cite:`devmysql`
+     Databases provide structure to a collection of data
+     while. :cite:`devmysql` A database management system allows for the
+     addition, accessing, and processing of the data stored in a
+     database. :cite:`devmysql` Relational databases utilize tables that are
+     broken down into columns, representing the various fields of the
+     table, and rows, which correspond to individual entries in the
+     table. :cite:`howmysql`
+     
 203. PostgreSQL
 
 204. CUBRID
@@ -1002,6 +1042,24 @@ NoSQL
      
 222. Riak
 223. ZHT
+
+     According to :cite:`datasys`, “ZHT is a zero-hop distributed hash
+     table.” Distributed hash tables effectively break a hash table up
+     and assign different nodes responsibility for managing different
+     pieces of the larger hash table. :cite:`wiley` To retrieve a value in a
+     distributed hash table, one needs to find the node that is
+     responsible for the managing the key value pair of
+     interest. :cite:`wiley` In general, every node that is a part of the
+     distributed hash table has a reference to the closest two nodes
+     in the node list. :cite:`wiley` In a ZHT, however, every node contains
+     information concerning the location of every other node. :cite:`Li`
+     Through this approach, ZHT aims to provide “high availability,
+     good fault tolerance, high throughput, and low latencies, at
+     extreme scales of millions of nodes.” :cite:`Li` Some of the defining
+     characteristics of ZHT are that it is light-weight, allows nodes
+     to join and leave dynamically, and utilizes replication to obtain
+     fault tolerance among others. :cite:`Li`
+     
 224. Berkeley DB
 225. Kyoto/Tokyo Cabinet
 226. Tycoon
@@ -1107,6 +1165,17 @@ NoSQL
      be administered by any JMX compliant tools.
 
 240. RYA
+
+     Rya is a “scalable system for storing and retrieving RDF data in
+     a cluster of nodes.” :cite:`Punnoose` RDF stands for Resource
+     Description Framework. :cite:`Punnoose` RDF is a model that facilitates
+     the exchange of data on a network. :cite:`w3` RDF utilizes a form
+     commonly referred to as a triple, an object that consists of a
+     subject, predicate, and object. :cite:`Punnoose` These triples are used
+     to describe resources on the Internet. :cite:`Punnoose` Through new
+     storage and querying techniques, Rya aims to make accessing RDF
+     data fast and easy. :cite:`apacherya`
+     
 241. Sqrrl
 242. Neo4J
 243. graphdb

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -184,7 +184,168 @@
 % enter your references here and delete this comment...
 
 % S17-IO-3004
-% enter your references here and delete this comment...
+
+@TechReport{kepes,
+  author      = {Ben Kepes},
+  title       = {Understanding the Cloud Computing Stack: SaaS, PaaS, IaaS},
+  institution = {Racspace},
+  year        = {2015},
+  type        = {white paper},
+  owner       = {S17-IO-3004},
+  url         = {https://support.rackspace.com/white-paper/understanding-the-cloud-computing-stack-saas-paas-iaas/},
+}
+
+@InBook{wee,
+  chapter   = {1},
+  title     = {Instant AppFog},
+  publisher = {Packt Publishing},
+  year      = {2013},
+  author    = {Pau Kiat Wee},
+  month     = {July},
+  owner     = {S17-IO-3004},
+  url       = {https://www.packtpub.com/mapt/book/Web-Development/9781782167624/1/ch01lvl1sec03/So,+what+is+AppFog%3F
+  },
+}
+
+@Misc{appfog,
+  author       = {appfog},
+  title        = {Overview},
+  howpublished = {Online},
+  owner        = {S17-IO-3004},
+  url          = {https://www.ctl.io/appfog/#Overview},
+}
+
+@Misc{tweney,
+  author       = {Dylan Tweney},
+  title        = {AppFog gives developers an easier way to deploy cloud apps (interview)},
+  howpublished = {Online},
+  month        = {May},
+  year         = {2012},
+  owner        = {S17-IO-3004},
+  url          = {http://venturebeat.com/2012/05/15/appfog-gives-developers-an-easier-way-to-deploy-cloud-apps-interview/},
+}
+
+@Misc{dream,
+  title        = {Overview},
+  howpublished = {Online},
+  note         = {The contact information listed on the webpage was for Yogesh Simmhan.},
+  owner        = {S17-IO-3004},
+  url          = {http://dream-lab.cds.iisc.ac.in/about/overview/},
+}
+
+@Book{denero,
+  title     = {CS61A: Online Textbook},
+  publisher = {Berkeley},
+  year      = {2011},
+  author    = {John Denero},
+  address   = {http://www-inst.eecs.berkeley.edu/~cs61a/sp12/book/},
+  note      = {"This book is derived from the classic textbook Structure and Interpretation of Computer Programs by Abelson, Sussman, and Sussman. John Denero originally modified if for Python for the Fall 2011 semester." http://www-inst.eecs.berkeley.edu/~cs61a/sp12/book/},
+  owner     = {S17-IO-3004},
+  url       = {http://www-inst.eecs.berkeley.edu/~cs61a/sp12/book/communication.html},
+}
+
+@Misc{devmysql,
+  author       = {mysql},
+  title        = {MySQL 5.7 Reference Manual, What is MySQL},
+  howpublished = {Online},
+  owner        = {S17-IO-3004},
+  url          = {https://dev.mysql.com/doc/refman/5.7/en/what-is-mysql.html},
+}
+
+@Misc{howmysql,
+  author       = {HowStuffWorks.com},
+  title        = {What are relational databases?},
+  howpublished = {Online},
+  month        = {March},
+  year         = {2001},
+  owner        = {S17-IO-3004},
+  timestamp    = {26 January 2017},
+  url          = {http://computer.howstuffworks.com/question599.htm},
+}
+
+@InProceedings{Li,
+  author    = {T. Li and X. Zhou and K. Brandstatter and D. Zhao and K. Wang and A. Rajendran and Z. Zhang and I. Raicu},
+  title     = {ZHT: A Light-Weight Reliable Persistent Dynamic Scalable Zero-Hop Distributed Hash Table},
+  booktitle = {2013 IEEE 27th International Symposium on Parallel and Distributed Processing},
+  year      = {2013},
+  pages     = {775-787},
+  month     = {May},
+  doi       = {10.1109/IPDPS.2013.110},
+  issn      = {1530-2075},
+  keywords  = {Linux;distributed databases;fault tolerant computing;meta data;parallel machines;performance evaluation;processor scheduling;storage management;FusionFS distributed file system;IBM Blue Gene/P supercomputer;IStore;Linux cluster;MATRIX;ZHT performance evaluation;distributed job scheduling system;distributed meta data management;distributed object storage system;fault tolerance;high-end computing systems;information dispersal algorithm;key-value stores;microbenchmarks;throughput;zero-hop distributed hash table;Fault tolerance;Fault tolerant systems;File systems;Generators;Routing;Servers;Throughput;Distributed hash tables;high-end computing;key/value stores},
+  owner     = {S17-IO-3004},
+  url       = {http://datasys.cs.iit.edu/publications/2013_IPDPS13_ZHT.pdf},
+}
+
+@Article{wiley,
+  author       = {Brandon Wiley},
+  title        = {Distributed Hash TTable, Part 1},
+  journal      = {Linux Journal},
+  year         = {2003},
+  number       = {114},
+  month        = {October},
+  note         = {From issue number 114},
+  howpublished = {Online},
+  owner        = {S17-IO-3004},
+  url          = {http://www.linuxjournal.com/article/6797?page=0,0},
+}
+
+@InProceedings{Punnoose,
+  author    = {Punnoose, Roshan and Crainiceanu, Adina and Rapp, David},
+  title     = {Rya: A Scalable RDF Triple Store for the Clouds},
+  booktitle = {Proceedings of the 1st International Workshop on Cloud Intelligence},
+  year      = {2012},
+  series    = {Cloud-I '12},
+  pages     = {4:1--4:8},
+  address   = {New York, NY, USA},
+  publisher = {ACM},
+  acmid     = {2347677},
+  articleno = {4},
+  doi       = {10.1145/2347673.2347677},
+  isbn      = {978-1-4503-1596-8},
+  keywords  = {RDF triple store, distributed, scalable},
+  location  = {Istanbul, Turkey},
+  numpages  = {8},
+  owner     = {S17-IO-3004},
+  url       = {http://doi.acm.org/10.1145/2347673.2347677},
+}
+
+@Misc{apacherya,
+  author       = {Apache Rya},
+  title        = {Apache Rya},
+  howpublished = {Online},
+  owner        = {S17-IO-3004},
+  url          = {https://rya.apache.org/},
+}
+
+@Misc{w3,
+  author       = {RDF Working Group},
+  title        = {Resource Description Framework (RDF)},
+  howpublished = {Online},
+  month        = {February},
+  year         = {2014},
+  owner        = {S17-IO-3004},
+  url          = {https://www.w3.org/RDF/},
+}
+
+@Misc{datasys,
+  author       = {Illinois Institute of Technology Department of Computer Science},
+  title        = {ZHT: a zero-hop distributed hashtable},
+  howpublished = {Online},
+  owner        = {S17-IO-3004},
+  url          = {http://datasys.cs.iit.edu/projects/ZHT/},
+}
+
+@Misc{rao,
+  author       = {Siddharth Rao},
+  title        = {DREAM:Lab – Democratising Computing through the Cloud},
+  howpublished = {Online},
+  month        = {March},
+  year         = {2016},
+  owner        = {S17-IO-3004},
+  url          = {http://iisc.researchmedia.center/article/dreamlab-%E2%80%93-democratising-computing-through-cloud
+  },
+}
 
 % S17-IO-3005
 


### PR DESCRIPTION
This is the Appfog, Dream:Lab, MySQL, ZHT, and Rya technology summaries and references.