### PR TITLE
fix: usr: add pdf url to any2api and spanner refs.

### DIFF
--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -2034,7 +2034,9 @@ key = 	 {Mahout},
   year      = {2015},
   pages     = {475­486},
   publisher = {SciTePress},
+  issn      = {2326-7550},
   owner     = {S17-IO-3005},
+  url       = {https://pdfs.semanticscholar.org/1cd4/4b87be8cf68ea5c4c642d38678a7b40a86de.pdf},
 }
 
 @Misc{www-any2api,
@@ -2055,6 +2057,7 @@ key = 	 {Mahout},
   pages     = {8},
   owner     = {S17-IO-3005},
   publisher = {ACM},
+  url       = {http://dl.acm.org/ft_gateway.cfm?id=2491245&type=pdf},
 }
 
 @Misc{www-magastore-spanner,


### PR DESCRIPTION
fixes:
- add pdf url to any2api and spanner refs.
- add issn to wettinger-any2api refs text.

As per review comments on commit#  fea96bc 
indentation is wrong I approve anyways, please fix in another pull request. [already fixed]
wettinger-any2api is incomplete [fixed]
pdfs available but not included in resf [fixed]