### PR TITLE
fix:usr: correct spelling of word references

### DIFF
--- a/docs/source/i524/index.rst
+++ b/docs/source/i524/index.rst
@@ -353,7 +353,7 @@ industry. CANVAS is not.
 As a consequence all technology papers from all students will be
 available as a single big technical report. To achieve this all
 reports must be written in the same format. This wil be LaTeX and all
-refernces have to be provided a bibtex file while you use jabref.
+references have to be provided a bibtex file while you use jabref.
 Alternatively lyx.org can be used, if you prefer to edit
 latex in *what you see is almost what you get* format. The use of
 sharelatex or overleave or lyx.org is allowed.
@@ -814,7 +814,7 @@ Please, select the course that is most suitable for your program:
 
 
 		 
-Refernces
+References
 ---------
 
 http://hpc-abds.org/kaleidoscope/ 

--- a/docs/source/i524/technologies.rst
+++ b/docs/source/i524/technologies.rst
@@ -2728,7 +2728,7 @@ Excersise
 
 TechList.1: In class you will be given an HID and you will be assigned
   a number of technologies that you need to research and create a
-  summary as well as one or more relevant refernces to be added to the
+  summary as well as one or more relevant references to be added to the
   Web page. All technologies for TechList.1 are marked with a (1)
   behind the technology.  An example text is given for Nagios in this
   page.  Please create a pull request with your responses. You are
@@ -2738,12 +2738,12 @@ TechList.1: In class you will be given an HID and you will be assigned
     new:usr: added paragraph about <PUTTECHHERE>
 
   You can create one or more pull requests for the technology and the
-  refernces. We have created in the referens file a placeholder using
-  your HID to simplify the management of the refernces while avoiding
+  references. We have created in the referens file a placeholder using
+  your HID to simplify the management of the references while avoiding
   conflicts.  For the technologies you are responsible to invesitgate
   them and write an academic summary of the technology. Make sure to
-  add your refernce to refs.bib.  Many technologies may have
-  additional refernces than the Web page. Please add the most
+  add your reference to refs.bib.  Many technologies may have
+  additional references than the Web page. Please add the most
   important once while limiting it to three if you can. Avoid
   plagearism and use proper quotations or better rewrite the text.
 
@@ -2818,7 +2818,7 @@ TechList.3:
 
 
 
-Refernces
+References
 ---------
 
 .. bibliography:: ../refs.bib


### PR DESCRIPTION
Change spelling from refernces to references in index.rst and technologies.rst.  Multiple occurrences.