### PR TITLE
fix:chg: remove dates where not explicitly specified in Mark McCombe references

### DIFF
--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -1408,9 +1408,7 @@
   Title =	 {Apache Incubator},
   Author =	 {{Apache Software Foundation}},
   HowPublished = {Web Page},
-  Month =	 jan,
   Note =	 {accessed 2017-01-29},
-  Year =	 2017,
   Owner =	 {S17-IO-3012},
   Url =          {http://incubator.apache.org/}
 }
@@ -1430,9 +1428,7 @@
   Title =	 {AWS OpsWorks},
   Author =	 {{Amazon}},
   HowPublished = {Web Page},
-  Month =	 jan,
   Note =	 {accessed 2017-01-25},
-  Year =	 2017,
   Owner =	 {S17-IO-3012},
   Url =		 {https://aws.amazon.com/opsworks/}
 }
@@ -1441,9 +1437,7 @@
   Title =	 {Cloud Bigtable},
   Author =	 {{Google}},
   HowPublished = {Web Page},
-  Month =	 jan,
   Note =	 {accessed 2017-01-29},
-  Year =	 2017,
   Owner =	 {S17-IO-3012},
   Url =		 {https://cloud.google.com/bigtable/}
 }
@@ -1475,9 +1469,7 @@
   Title =	 {IBM Spectrum Scale},
   Author =	 {{IBM}},
   HowPublished = {Web Page},
-  Month =	 jan,
   Note =	 {accessed 2017-01-29},
-  Year =	 2017,
   Owner =	 {S17-IO-3012},
   Url =
                   {http://www-03.ibm.com/systems/storage/spectrum/scale/}


### PR DESCRIPTION
remove dates where not explicitly specified in Mark McCombe references