### PR TITLE
new:dev: Adding Blazegraph explanation after re-fork

### DIFF
--- a/docs/source/i524/technologies.rst
+++ b/docs/source/i524/technologies.rst
@@ -3928,6 +3928,28 @@ NoSQL
      be queried.  :cite:`www-Allegrow`
 
 246. Blazegraph
+
+     Blazegraph is a graph database also supporting property graph, 
+     capable of clustered deployment. A graph database is a NoSQL 
+     database. It is based on a graph theory of nodes and edges where 
+     each node represents an element such as user or business and each 
+     edge represents relationship between two nodes. It is mainly used 
+     for storing and analyzing data where maintaining interconnections 
+     is essential. Data pertaining to social media is best example where 
+     graph database can be used.
+
+     Blazegraph’s main focus is large scale complex graph analytics and query. 
+     The Blazegraph database runs on graphics processing units (GPU) to 
+     speed graph traversals. :cite ‘paper-blzgraph’
+
+     Lets now see how Blazegraph handles data. :cite ‘www-blzgraph’ 
+     **Blazegraph data can be accessed** using REST APIs. 
+
+     **Blazegraph supports** Apache TinkerPop, which is a graph computing framework.
+
+     **For graph data mining,** Blazegraph implements GAS (Gather, Apply, 
+     Scatter) model as a service.
+
 247. Facebook Tao
 
      In the paper published in USENIX annual technical conference, 

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -2297,6 +2297,28 @@
   url          = {https://www.mongodb.com/compare/mongodb-mysql},
 }
 
+@Misc{www-blzgraph,
+  author       	= {Systap},
+  title        	= {Blazegraph Wiki},
+  howpublished 	= {Web Page},
+  month        	= {Aug},
+  year         	= {2008},
+  note         	= {Page was last modified on 25 Jan 2016},
+  owner		= {S17-IO-3017},
+  url          	= {https://wiki.blazegraph.com/wiki/index.php/Main_Page},
+}
+
+@InProceedings{paper-blzgraph,
+  author = {Philip Howard},
+  title  = {Blazegraph GPU},
+  year   = {2015},
+  pages  = {13},
+  month  = {December},
+  note   = {White Paper},
+  owner  = {S17-IO-3017},
+  url    = {https://www.blazegraph.com/whitepapers/Blazegraph-gpu_InDetail_BloorResearch.pdf},
+}
+
 
 % S17-IO-3018
 


### PR DESCRIPTION
Adding Blazegraph explanation after re-fork. Re-fork was done as there were too many conflicts.